### PR TITLE
Limit results

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -482,8 +482,9 @@ func Toadua(args []string, howMany int, returnText func(string)) {
 		soFar = b.String()
 		if len(soFar) > 2000 {
 			returnText(old)
-			b.Reset()
-			b.WriteString(soFar[len(old):])
+			return
+			// b.Reset()
+			// b.WriteString(soFar[len(old):])
 		}
 	}
 	returnText(b.String())


### PR DESCRIPTION
There is probably no legitimate reason for nuogaı to send more than one message worth of results; it mostly just leads to accidents like "someone spamming #test with every word that exists because they didn't think it would actually work."